### PR TITLE
Fix printing of negative symbolic variables

### DIFF
--- a/src/rolling_stones/core.clj
+++ b/src/rolling_stones/core.clj
@@ -144,7 +144,7 @@
 (defmethod clojure.core/print-method Not [x writer]
   (binding [*out* writer]
     (print "(! ")
-    (print (:literal x))
+    (pr (:literal x))
     (print ")")))
 
 (. clojure.pprint/simple-dispatch addMethod Not #(clojure.core/print-method % *out*))


### PR DESCRIPTION
It looks like there was a small bug in printing of negative symbolic variables if the variable included a string. I think this fixes it. Patch may also include a newline at the end of the file.