### PR TITLE
Add exclusion for abs function in clojure core

### DIFF
--- a/src/rolling_stones/core.clj
+++ b/src/rolling_stones/core.clj
@@ -1,4 +1,5 @@
 (ns rolling-stones.core
+  (:refer-clojure :exclude [abs])
   (:require [better-cond.core :as b]
             [clojure.spec.alpha :as s]
             [clojure.pprint])


### PR DESCRIPTION
`abs` was added in clojure 1.11. Adding this exclusion suppresses warnings like
```
WARNING: abs already refers to: #'clojure.core/abs in namespace: rolling-stones.core, being replaced by: #'rolling-stones.core/abs
```